### PR TITLE
Add marshaling and remove PEM methods

### DIFF
--- a/binding_test.go
+++ b/binding_test.go
@@ -1,46 +1,10 @@
 package ctidh
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestPrivateKeyPEMSerialization(t *testing.T) {
-	privateKey, _ := GenerateKeyPair()
-
-	tmpdir := os.TempDir()
-
-	privateKeyPemFile := "private_key.pem"
-	pemFile := filepath.Join(tmpdir, privateKeyPemFile)
-	err := privateKey.ToPEMFile(pemFile)
-	require.NoError(t, err)
-
-	privateKey2 := NewEmptyPrivateKey()
-	err = privateKey2.FromPEMFile(pemFile)
-	require.NoError(t, err)
-
-	require.Equal(t, privateKey.Bytes(), privateKey2.Bytes())
-}
-
-func TestPublicKeyPEMSerialization(t *testing.T) {
-	_, publicKey := GenerateKeyPair()
-
-	tmpdir := os.TempDir()
-
-	publicKeyPemFile := "public_key.pem"
-	pemFile := filepath.Join(tmpdir, publicKeyPemFile)
-	err := publicKey.ToPEMFile(pemFile)
-	require.NoError(t, err)
-
-	publicKey2 := NewEmptyPublicKey()
-	err = publicKey2.FromPEMFile(pemFile)
-	require.NoError(t, err)
-
-	require.Equal(t, publicKey.Bytes(), publicKey2.Bytes())
-}
 
 func TestPublicKeyReset(t *testing.T) {
 	zeros := make([]byte, PublicKeySize)


### PR DESCRIPTION
we have a general purpose pem module in core/crypto/pem which we should use instead of reimplementing pem over and over again. this simple PR removes the PEM stuff but it adds methods for binary and test marshaling and unmashaling interfaces... this should be preferably if you are writing CTIDH keys into a statefile via CBOR or something like that?